### PR TITLE
include Luftdaten device ID in debug output

### DIFF
--- a/server.js
+++ b/server.js
@@ -35,10 +35,9 @@ const sendData = (url, payload, deviceId, XPin) => {
 ttn.data(appID, accessKey)
     .then((client) => {
       client.on('uplink', (devID, payload) => {
-        log('Forwarding data from device: ' + devID)
-        log('data: ' + JSON.stringify(payload.payload_fields))
-
         const deviceId = prefix + '-' + parseInt(payload.hardware_serial, 16)
+        log('Forwarding data from device: ' + devID + ' [' + deviceId + ']')
+        log('data: ' + JSON.stringify(payload.payload_fields))
 
         if (payload.payload_fields.pm10 && payload.payload_fields.pm25) {
           const pmPayload = [


### PR DESCRIPTION
Because it would be nice to see it in the debug output too. Otherwise it's not always clear, which device ID gets generated exactly.